### PR TITLE
(fix) remittanceInformation is a required field for the desinationAccount

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -14,6 +14,10 @@ const destinationAccount = {
   ],
   recipientName: 'Demo Store AB',
   sourceMessage: 'Payment for Sneaker 034',
+  remittanceInformation: {
+    type: "UNSTRUCTURED",
+    value: "3245928392092"
+  },
 };
 
 const log = function (...args) {


### PR DESCRIPTION
Payload for this example is missing the remittanceInformation, which currently breaks the flow of the example.

```
{
  errorMessage: "Failed to create payment request. Reason: Request must have remittance information defined.",
  errorCode: "payment_request.remittance_information_missing",
}
```

By including remittanceInformation, this allows to flow to continue to tink link as expected.